### PR TITLE
user was point to id 4 always - fix to pull correct user

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Item 1: line 64 on views/profile.py was user = 4 changed to request.auth.user

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/profile` Getting a a profile

```json
{
    "id": 7,
    "url": "http://localhost:8000/customers/7",
    "user": {
        "first_name": "Brenda",
        "last_name": "Long",
        "email": "brenda@brendalong.com"
    },
    "phone_number": "555-1212",
    "address": "100 Indefatiguable Way",
    "payment_types": [
        {
            "url": "http://localhost:8000/paymenttypes/3",
            "deleted": null,
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11",
            "customer": "http://localhost:8000/customers/7"
        }
    ]
}
```

**Response**

HTTP/1.1" 200 OK


## Testing

Description of how to test code...

- [ ] Run Get profile
- [ ] Internal Server Error: /profile HTTP/1.1" 500
- [ ] Noticed was user pointing to id 4 only on line 64 for views/profile.py
- [ ] update that and run got correct user.


## Related Issues

- Fixes #3 
